### PR TITLE
Textarea resize set to only be vertical

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2183,6 +2183,7 @@
 		padding: 0 1rem;
 		text-decoration: none;
 		width: 100%;
+		resize: vertical;
 	}
 
 		input[type="text"]:invalid,


### PR DESCRIPTION
Textarea in footer was able to be resized horizontally pushing person contact details outside of the bounds of the div. Changed resize to only include vertical resize as is common practice.

Simple edit, can also just completely limit resizing, but this defeats the general purpose of a text area form. Additionally this imitates the behaviour of textareas on github.